### PR TITLE
Add gymnastics industry configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WP Studio Manager
 
-WP Studio Manager is a modular WordPress plugin for managing classes, instructors and clients across many industries. The project began as a gymnastics management tool but now targets a wide range of studios including fitness, education, creative workshops and wellness centers. The plugin provides an extensible architecture with a flexible industry configuration system.
+WP Studio Manager is a modular WordPress plugin for managing classes, instructors and clients across many industries. The project began as a gymnastics management tool but now targets a wide range of studios including fitness, education, creative workshops, gymnastics programs and wellness centers. The plugin provides an extensible architecture with a flexible industry configuration system that adapts terminology for gyms, private trainers and studios alike.
 
 ## Project Goals
 - Replace expensive SaaS solutions like iClassPro and MindBody with a WordPress based alternative.

--- a/wp-studio-manager/includes/industry_configs/class-industry-config.php
+++ b/wp-studio-manager/includes/industry_configs/class-industry-config.php
@@ -27,6 +27,14 @@ class Industry_Config {
             'required_fields'   => ['experience_level', 'materials_owned'],
             'integrations'      => ['portfolio_sites', 'social_sharing'],
         ],
+        'gymnastics' => [
+            'participant_label' => 'Athlete',
+            'session_label'     => 'Practice',
+            'instructor_label'  => 'Coach',
+            'features'          => ['skill_tracking', 'meet_management', 'routine_videos'],
+            'required_fields'   => ['usag_number', 'emergency_contact', 'medical_conditions'],
+            'integrations'      => ['scoring_systems', 'competition_registration'],
+        ],
     ];
 
     public static function get_config($industry = null) {


### PR DESCRIPTION
## Summary
- extend industry configurations to include a gymnastics profile
- clarify README about multiple studio types

## Testing
- `php -l wp-studio-manager/includes/industry_configs/class-industry-config.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68464757acb083218322dc68def24a96