### PR TITLE
Add industry configuration templates

### DIFF
--- a/wp-studio-manager/admin/setup/configuration-templates.php
+++ b/wp-studio-manager/admin/setup/configuration-templates.php
@@ -1,1 +1,23 @@
-<?php\n// TODO: implement
+<?php
+use WSM\Includes\Industry_Configs\Fitness_Config;
+use WSM\Includes\Industry_Configs\Education_Config;
+use WSM\Includes\Industry_Configs\Creative_Config;
+use WSM\Includes\Industry_Configs\Sports_Config;
+use WSM\Includes\Industry_Configs\Wellness_Config;
+
+if (!function_exists('wsm_get_industry_templates')) {
+    /**
+     * Return the default configuration templates for all industries.
+     *
+     * @return array
+     */
+    function wsm_get_industry_templates() {
+        return [
+            'fitness'    => Fitness_Config::get(),
+            'education'  => Education_Config::get(),
+            'creative'   => Creative_Config::get(),
+            'sports'     => Sports_Config::get(),
+            'wellness'   => Wellness_Config::get(),
+        ];
+    }
+}

--- a/wp-studio-manager/documentation/examples/industry-templates.md
+++ b/wp-studio-manager/documentation/examples/industry-templates.md
@@ -1,1 +1,23 @@
-# Placeholder
+# Industry Configuration Templates
+
+WP Studio Manager ships with several predefined industry templates. Each template customizes terminology and enables features relevant to a specific type of business.
+
+## Fitness Studios
+- **Member management with health tracking**
+- **Class scheduling with capacity limits**
+- **Membership packages and drop-ins**
+- **Progress tracking and body composition**
+
+## Educational Centers
+- **Student/parent relationship management**
+- **Lesson scheduling with recurrence**
+- **Progress reports and skill tracking**
+- **Assignment and homework management**
+
+## Creative Studios
+- **Workshop-based scheduling**
+- **Supply list management**
+- **Project portfolio tracking**
+- **Certificate/completion tracking**
+
+These templates are loaded through the `Industry_Config` class and can be extended or modified by developers.

--- a/wp-studio-manager/includes/industry-configs/class-creative-config.php
+++ b/wp-studio-manager/includes/industry-configs/class-creative-config.php
@@ -1,1 +1,0 @@
-<?php\n// TODO: implement

--- a/wp-studio-manager/includes/industry-configs/class-education-config.php
+++ b/wp-studio-manager/includes/industry-configs/class-education-config.php
@@ -1,1 +1,0 @@
-<?php\n// TODO: implement

--- a/wp-studio-manager/includes/industry-configs/class-fitness-config.php
+++ b/wp-studio-manager/includes/industry-configs/class-fitness-config.php
@@ -1,1 +1,0 @@
-<?php\n// TODO: implement

--- a/wp-studio-manager/includes/industry-configs/class-sports-config.php
+++ b/wp-studio-manager/includes/industry-configs/class-sports-config.php
@@ -1,1 +1,0 @@
-<?php\n// TODO: implement

--- a/wp-studio-manager/includes/industry-configs/class-wellness-config.php
+++ b/wp-studio-manager/includes/industry-configs/class-wellness-config.php
@@ -1,1 +1,0 @@
-<?php\n// TODO: implement

--- a/wp-studio-manager/includes/industry_configs/class-creative-config.php
+++ b/wp-studio-manager/includes/industry_configs/class-creative-config.php
@@ -1,0 +1,25 @@
+<?php
+namespace WSM\Includes\Industry_Configs;
+
+class Creative_Config {
+    /**
+     * Return the configuration array for creative studios.
+     *
+     * @return array
+     */
+    public static function get() {
+        return [
+            'participant_label' => 'Artist',
+            'session_label'     => 'Workshop',
+            'instructor_label'  => 'Instructor',
+            'features'          => [
+                'workshop_scheduling',
+                'supply_lists',
+                'project_portfolios',
+                'certificate_tracking',
+            ],
+            'required_fields'   => ['experience_level', 'materials_owned'],
+            'integrations'      => ['portfolio_sites', 'social_sharing'],
+        ];
+    }
+}

--- a/wp-studio-manager/includes/industry_configs/class-education-config.php
+++ b/wp-studio-manager/includes/industry_configs/class-education-config.php
@@ -1,0 +1,27 @@
+<?php
+namespace WSM\Includes\Industry_Configs;
+
+class Education_Config {
+    /**
+     * Return the configuration array for educational centers.
+     *
+     * @return array
+     */
+    public static function get() {
+        return [
+            'participant_label' => 'Student',
+            'session_label'     => 'Lesson',
+            'instructor_label'  => 'Teacher',
+            'features'          => [
+                'relationship_management',
+                'lesson_recurrence',
+                'progress_reports',
+                'skill_tracking',
+                'assignment_management',
+                'homework_management',
+            ],
+            'required_fields'   => ['skill_level', 'instrument', 'parent_contact'],
+            'integrations'      => ['practice_tracking', 'sheet_music'],
+        ];
+    }
+}

--- a/wp-studio-manager/includes/industry_configs/class-fitness-config.php
+++ b/wp-studio-manager/includes/industry_configs/class-fitness-config.php
@@ -1,0 +1,27 @@
+<?php
+namespace WSM\Includes\Industry_Configs;
+
+class Fitness_Config {
+    /**
+     * Return the configuration array for fitness studios.
+     *
+     * @return array
+     */
+    public static function get() {
+        return [
+            'participant_label' => 'Member',
+            'session_label'     => 'Class',
+            'instructor_label'  => 'Trainer',
+            'features'          => [
+                'health_tracking',
+                'capacity_limits',
+                'membership_packages',
+                'drop_ins',
+                'progress_tracking',
+                'body_composition',
+            ],
+            'required_fields'   => ['emergency_contact', 'health_conditions'],
+            'integrations'      => ['heart_rate_monitors', 'nutrition_tracking'],
+        ];
+    }
+}

--- a/wp-studio-manager/includes/industry_configs/class-industry-config.php
+++ b/wp-studio-manager/includes/industry_configs/class-industry-config.php
@@ -2,42 +2,32 @@
 namespace WSM\Includes\Industry_Configs;
 
 class Industry_Config {
-    private static $configs = [
-        'fitness' => [
-            'participant_label' => 'Member',
-            'session_label'     => 'Class',
-            'instructor_label'  => 'Trainer',
-            'features'          => ['body_composition', 'progress_photos', 'workout_plans'],
-            'required_fields'   => ['emergency_contact', 'health_conditions'],
-            'integrations'      => ['heart_rate_monitors', 'nutrition_tracking'],
-        ],
-        'education' => [
-            'participant_label' => 'Student',
-            'session_label'     => 'Lesson',
-            'instructor_label'  => 'Teacher',
-            'features'          => ['progress_tracking', 'assignments', 'recitals'],
-            'required_fields'   => ['skill_level', 'instrument', 'parent_contact'],
-            'integrations'      => ['practice_tracking', 'sheet_music'],
-        ],
-        'creative' => [
-            'participant_label' => 'Artist',
-            'session_label'     => 'Workshop',
-            'instructor_label'  => 'Instructor',
-            'features'          => ['portfolio', 'supply_lists', 'project_gallery'],
-            'required_fields'   => ['experience_level', 'materials_owned'],
-            'integrations'      => ['portfolio_sites', 'social_sharing'],
-        ],
-        'gymnastics' => [
+    private static $configs = null;
+
+    private static function load_configs() {
+        if (self::$configs !== null) {
+            return;
+        }
+
+        self::$configs = [
+            'fitness'    => Fitness_Config::get(),
+            'education'  => Education_Config::get(),
+            'creative'   => Creative_Config::get(),
+            'sports'     => Sports_Config::get(),
+            'wellness'   => Wellness_Config::get(),
+            'gymnastics' => [
             'participant_label' => 'Athlete',
             'session_label'     => 'Practice',
             'instructor_label'  => 'Coach',
             'features'          => ['skill_tracking', 'meet_management', 'routine_videos'],
             'required_fields'   => ['usag_number', 'emergency_contact', 'medical_conditions'],
             'integrations'      => ['scoring_systems', 'competition_registration'],
-        ],
-    ];
+            ],
+        ];
+    }
 
     public static function get_config($industry = null) {
+        self::load_configs();
         if (!$industry) {
             $industry = get_option('wsm_industry', 'fitness');
         }

--- a/wp-studio-manager/includes/industry_configs/class-sports-config.php
+++ b/wp-studio-manager/includes/industry_configs/class-sports-config.php
@@ -1,0 +1,15 @@
+<?php
+namespace WSM\Includes\Industry_Configs;
+
+class Sports_Config {
+    public static function get() {
+        return [
+            'participant_label' => 'Athlete',
+            'session_label'     => 'Practice',
+            'instructor_label'  => 'Coach',
+            'features'          => ['skill_tracking'],
+            'required_fields'   => ['emergency_contact'],
+            'integrations'      => [],
+        ];
+    }
+}

--- a/wp-studio-manager/includes/industry_configs/class-wellness-config.php
+++ b/wp-studio-manager/includes/industry_configs/class-wellness-config.php
@@ -1,0 +1,15 @@
+<?php
+namespace WSM\Includes\Industry_Configs;
+
+class Wellness_Config {
+    public static function get() {
+        return [
+            'participant_label' => 'Client',
+            'session_label'     => 'Session',
+            'instructor_label'  => 'Practitioner',
+            'features'          => [],
+            'required_fields'   => ['health_conditions'],
+            'integrations'      => [],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- implement fitness, education, creative, sports and wellness configuration classes
- provide factory for configuration templates in setup wizard
- update central `Industry_Config` to load configs lazily
- document available industry templates

## Testing
- `php -l wp-studio-manager/includes/industry_configs/class-fitness-config.php`
- `php -l wp-studio-manager/includes/industry_configs/class-education-config.php`
- `php -l wp-studio-manager/includes/industry_configs/class-creative-config.php`
- `php -l wp-studio-manager/includes/industry_configs/class-sports-config.php`
- `php -l wp-studio-manager/includes/industry_configs/class-wellness-config.php`
- `php -l wp-studio-manager/includes/industry_configs/class-industry-config.php`
- `php -l wp-studio-manager/admin/setup/configuration-templates.php`


------
https://chatgpt.com/codex/tasks/task_e_68464843f0b483218cb84f3e1bc840d7