### PR TITLE
Implement industry-aware fields and navigation fix

### DIFF
--- a/wp-studio-manager/admin/controllers/admin-menu.php
+++ b/wp-studio-manager/admin/controllers/admin-menu.php
@@ -1,18 +1,24 @@
 <?php
 // Add admin menu
+use WSM\Includes\Industry_Configs\Industry_Config;
+
 function gm_add_admin_menu() {
-    add_menu_page('Gymnastics Management', 'Gym Management', 'manage_options', 'gym-management', 'gm_admin_page', 'dashicons-groups', 6);
-    add_submenu_page('gym-management', 'Coaches', 'Coaches', 'manage_options', 'gym-coaches', 'gm_coaches_page');
-    add_submenu_page('gym-management', 'Parents', 'Athletes', 'manage_options', 'gym-parents', 'gm_parents_page');
+    $instructor  = Industry_Config::get_label('instructor_label', true);
+    $participant = Industry_Config::get_label('participant_label', true);
+    $session     = Industry_Config::get_label('session_label', true);
+
+    add_menu_page('Studio Management', 'Studio Management', 'manage_options', 'gym-management', 'gm_admin_page', 'dashicons-groups', 6);
+    add_submenu_page('gym-management', $instructor, $instructor, 'manage_options', 'gym-coaches', 'gm_coaches_page');
+    add_submenu_page('gym-management', $participant, $participant, 'manage_options', 'gym-parents', 'gm_parents_page');
     add_submenu_page('gym-management', 'Levels', 'Levels', 'manage_options', 'gym-levels', 'gm_levels_page');
-    add_submenu_page('gym-management', 'Classes', 'Classes', 'manage_options', 'gym-classes', 'gm_classes_page');
+    add_submenu_page('gym-management', $session, $session, 'manage_options', 'gym-classes', 'gm_classes_page');
 }
 add_action('admin_menu', 'gm_add_admin_menu');
 
 // Function to display the dashboard page with actionable tiles
 function gm_admin_page() {
-    echo '<h1>Gymnastics Management Dashboard</h1>';
-    echo '<p>Welcome to the Gymnastics Management plugin. Use the menu on the left to navigate through the features.</p>';
+    echo '<h1>Studio Management Dashboard</h1>';
+    echo '<p>Welcome to the WP Studio Manager plugin. Use the menu on the left to navigate through the features.</p>';
 
 
     $actions = [
@@ -130,7 +136,8 @@ function gm_enqueue_admin_scripts($hook_suffix) {
             wp_localize_script('gm-classes-script', 'wsmClasses', array(
                 'adminPostUrl' => admin_url('admin-post.php'),
                 'adminAjaxUrl' => admin_url('admin-ajax.php'),
-                'deleteNonce'  => wp_create_nonce('delete_class_nonce')
+                'deleteNonce'  => wp_create_nonce('delete_class_nonce'),
+                'currentPage'  => esc_url_raw($_SERVER['REQUEST_URI'])
             ));
         }
     }

--- a/wp-studio-manager/admin/controllers/class-participants-controller.php
+++ b/wp-studio-manager/admin/controllers/class-participants-controller.php
@@ -1,1 +1,35 @@
-<?php\n// TODO: implement
+<?php
+namespace WSM\Admin\Controllers;
+
+use WSM\Includes\Utilities\Industry_Helper;
+use WSM\Includes\Industry_Configs\Industry_Config;
+
+class Participants_Controller {
+    public static function register() {
+        add_action('admin_menu', [__CLASS__, 'add_menu']);
+    }
+
+    public static function add_menu() {
+        add_menu_page(
+            Industry_Config::get_label('participant_label', true),
+            Industry_Config::get_label('participant_label', true),
+            'manage_options',
+            'wsm-participants',
+            [__CLASS__, 'render_page']
+        );
+    }
+
+    public static function render_page() {
+        if (!current_user_can('manage_options')) {
+            return;
+        }
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html(Industry_Config::get_label('participant_label', true)) . '</h1>';
+        echo '<form method="post">';
+        Industry_Helper::render_fields('participant');
+        submit_button('Save');
+        echo '</form></div>';
+    }
+}
+
+Participants_Controller::register();

--- a/wp-studio-manager/assets/js/admin/classes.js
+++ b/wp-studio-manager/assets/js/admin/classes.js
@@ -63,7 +63,7 @@
                     headers: {'Content-Type': 'application/x-www-form-urlencoded'},
                     body: 'action=gm_remove_athlete&class_id=' + classId + '&athlete_id=' + athleteId
                 }).then(r => r.text()).then(data => {
-                    if(data === 'success'){ location.reload(); } else { console.error('Failed to remove athlete'); }
+                    if(data === 'success'){ window.location.href = wsmClasses.currentPage; } else { console.error('Failed to remove athlete'); }
                 });
             });
         });
@@ -77,7 +77,7 @@
                     headers: {'Content-Type': 'application/x-www-form-urlencoded'},
                     body: 'action=gm_remove_coach&class_id=' + classId + '&coach_id=' + coachId
                 }).then(r => r.text()).then(data => {
-                    if(data === 'success'){ location.reload(); } else { console.error('Failed to remove coach'); }
+                    if(data === 'success'){ window.location.href = wsmClasses.currentPage; } else { console.error('Failed to remove coach'); }
                 });
             });
         });
@@ -189,7 +189,7 @@
                     headers: {'Content-Type': 'application/x-www-form-urlencoded'},
                     body: 'action=gm_delete_class&class_id=' + classId + '&_wpnonce=' + deleteNonce
                 }).then(r => r.text()).then(data => {
-                    if(data === 'success'){ location.reload(); } else { console.error('Failed to delete class'); }
+                    if(data === 'success'){ window.location.href = wsmClasses.currentPage; } else { console.error('Failed to delete class'); }
                 });
             }
         });

--- a/wp-studio-manager/core/class-wsm-activator.php
+++ b/wp-studio-manager/core/class-wsm-activator.php
@@ -1,1 +1,8 @@
-<?php\n// TODO: implement
+<?php
+namespace WSM\Core;
+
+class WSM_Activator {
+    public static function activate() {
+        flush_rewrite_rules();
+    }
+}

--- a/wp-studio-manager/core/class-wsm-deactivator.php
+++ b/wp-studio-manager/core/class-wsm-deactivator.php
@@ -1,1 +1,8 @@
-<?php\n// TODO: implement
+<?php
+namespace WSM\Core;
+
+class WSM_Deactivator {
+    public static function deactivate() {
+        flush_rewrite_rules();
+    }
+}

--- a/wp-studio-manager/core/class-wsm-industry-config.php
+++ b/wp-studio-manager/core/class-wsm-industry-config.php
@@ -1,1 +1,14 @@
-<?php\n// TODO: implement
+<?php
+namespace WSM\Core;
+
+use WSM\Includes\Industry_Configs\Industry_Config;
+
+class WSM_Industry_Config {
+    public static function get_label($key, $plural = false) {
+        return Industry_Config::get_label($key, $plural);
+    }
+
+    public static function get_config($industry = null) {
+        return Industry_Config::get_config($industry);
+    }
+}

--- a/wp-studio-manager/core/class-wsm-loader.php
+++ b/wp-studio-manager/core/class-wsm-loader.php
@@ -1,1 +1,24 @@
-<?php\n// TODO: implement
+<?php
+namespace WSM\Core;
+
+class WSM_Loader {
+    public static function register() {
+        spl_autoload_register([__CLASS__, 'autoload']);
+    }
+
+    public static function autoload($class) {
+        if (strpos($class, 'WSM\\') !== 0) {
+            return;
+        }
+        $relative = substr($class, 4);
+        $relative = str_replace('\\', '/', $relative);
+        $parts    = explode('/', $relative);
+        $class_name = array_pop($parts);
+        $path  = strtolower(implode('/', $parts));
+        $file  = WSM_PLUGIN_DIR . ($path ? $path . '/' : '');
+        $file .= 'class-' . strtolower(str_replace('_', '-', $class_name)) . '.php';
+        if (file_exists($file)) {
+            include $file;
+        }
+    }
+}

--- a/wp-studio-manager/core/class-wsm-plugin.php
+++ b/wp-studio-manager/core/class-wsm-plugin.php
@@ -1,1 +1,17 @@
-<?php\n// TODO: implement
+<?php
+namespace WSM\Core;
+
+class WSM_Plugin {
+    private static $instance = null;
+
+    public static function instance() {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    public function run() {
+        // Additional bootstrapping can occur here
+    }
+}

--- a/wp-studio-manager/includes/industry_configs/class-creative-config.php
+++ b/wp-studio-manager/includes/industry_configs/class-creative-config.php
@@ -20,6 +20,15 @@ class Creative_Config {
             ],
             'required_fields'   => ['experience_level', 'materials_owned'],
             'integrations'      => ['portfolio_sites', 'social_sharing'],
+            'custom_fields'     => [
+                'participant' => [
+                    'experience_level' => ['label' => 'Experience Level', 'type' => 'text'],
+                    'materials_owned'  => ['label' => 'Materials Owned', 'type' => 'textarea'],
+                ],
+                'session' => [
+                    'supplies_needed' => ['label' => 'Supplies Needed', 'type' => 'textarea'],
+                ],
+            ],
         ];
     }
 }

--- a/wp-studio-manager/includes/industry_configs/class-education-config.php
+++ b/wp-studio-manager/includes/industry_configs/class-education-config.php
@@ -22,6 +22,15 @@ class Education_Config {
             ],
             'required_fields'   => ['skill_level', 'instrument', 'parent_contact'],
             'integrations'      => ['practice_tracking', 'sheet_music'],
+            'custom_fields'     => [
+                'participant' => [
+                    'skill_level'    => ['label' => 'Skill Level', 'type' => 'text', 'required' => true],
+                    'instrument'     => ['label' => 'Instrument', 'type' => 'text'],
+                ],
+                'session' => [
+                    'room'   => ['label' => 'Room', 'type' => 'text'],
+                ],
+            ],
         ];
     }
 }

--- a/wp-studio-manager/includes/industry_configs/class-fitness-config.php
+++ b/wp-studio-manager/includes/industry_configs/class-fitness-config.php
@@ -22,6 +22,18 @@ class Fitness_Config {
             ],
             'required_fields'   => ['emergency_contact', 'health_conditions'],
             'integrations'      => ['heart_rate_monitors', 'nutrition_tracking'],
+            'custom_fields'     => [
+                'participant' => [
+                    'emergency_contact'  => ['label' => 'Emergency Contact', 'type' => 'text', 'required' => true],
+                    'health_conditions'  => ['label' => 'Health Conditions', 'type' => 'textarea'],
+                ],
+                'session' => [
+                    'difficulty' => ['label' => 'Difficulty', 'type' => 'select', 'options' => ['Beginner','Intermediate','Advanced']],
+                ],
+                'instructor' => [
+                    'certifications' => ['label' => 'Certifications', 'type' => 'textarea'],
+                ],
+            ],
         ];
     }
 }

--- a/wp-studio-manager/includes/industry_configs/class-industry-config.php
+++ b/wp-studio-manager/includes/industry_configs/class-industry-config.php
@@ -22,6 +22,12 @@ class Industry_Config {
             'features'          => ['skill_tracking', 'meet_management', 'routine_videos'],
             'required_fields'   => ['usag_number', 'emergency_contact', 'medical_conditions'],
             'integrations'      => ['scoring_systems', 'competition_registration'],
+            'custom_fields'     => [
+                'participant' => [
+                    'usag_number'       => ['label' => 'USAG Number', 'type' => 'text', 'required' => true],
+                    'medical_conditions' => ['label' => 'Medical Conditions', 'type' => 'textarea'],
+                ],
+            ],
             ],
         ];
     }

--- a/wp-studio-manager/includes/industry_configs/class-sports-config.php
+++ b/wp-studio-manager/includes/industry_configs/class-sports-config.php
@@ -10,6 +10,11 @@ class Sports_Config {
             'features'          => ['skill_tracking'],
             'required_fields'   => ['emergency_contact'],
             'integrations'      => [],
+            'custom_fields'     => [
+                'participant' => [
+                    'emergency_contact' => ['label' => 'Emergency Contact', 'type' => 'text', 'required' => true],
+                ],
+            ],
         ];
     }
 }

--- a/wp-studio-manager/includes/industry_configs/class-wellness-config.php
+++ b/wp-studio-manager/includes/industry_configs/class-wellness-config.php
@@ -10,6 +10,11 @@ class Wellness_Config {
             'features'          => [],
             'required_fields'   => ['health_conditions'],
             'integrations'      => [],
+            'custom_fields'     => [
+                'participant' => [
+                    'health_conditions' => ['label' => 'Health Conditions', 'type' => 'textarea'],
+                ],
+            ],
         ];
     }
 }

--- a/wp-studio-manager/includes/traits/trait-industry-aware.php
+++ b/wp-studio-manager/includes/traits/trait-industry-aware.php
@@ -1,1 +1,10 @@
-<?php\n// TODO: implement
+<?php
+namespace WSM\Includes\Traits;
+
+use WSM\Includes\Industry_Configs\Industry_Config;
+
+trait Industry_Aware {
+    protected function label($key, $plural = false) {
+        return Industry_Config::get_label($key, $plural);
+    }
+}

--- a/wp-studio-manager/includes/utilities/class-industry-helper.php
+++ b/wp-studio-manager/includes/utilities/class-industry-helper.php
@@ -1,1 +1,52 @@
-<?php\n// TODO: implement
+<?php
+namespace WSM\Includes\Utilities;
+
+use WSM\Includes\Industry_Configs\Industry_Config;
+
+/**
+ * Helper functions for industry-specific logic.
+ */
+class Industry_Helper {
+    /**
+     * Get custom fields for an entity based on the current industry.
+     *
+     * @param string $entity participant|session|instructor
+     * @return array
+     */
+    public static function get_entity_fields($entity) {
+        $config = Industry_Config::get_config();
+        return $config['custom_fields'][$entity] ?? [];
+    }
+
+    /**
+     * Render HTML form inputs for a given entity.
+     *
+     * @param string $entity
+     * @param array  $values
+     */
+    public static function render_fields($entity, array $values = []) {
+        $fields = self::get_entity_fields($entity);
+        foreach ($fields as $key => $field) {
+            $label = esc_html($field['label']);
+            $type  = $field['type'] ?? 'text';
+            $val   = esc_attr($values[$key] ?? '');
+            echo '<p><label>' . $label . '<br />';
+            switch ($type) {
+                case 'textarea':
+                    echo '<textarea name="' . esc_attr($key) . '">' . $val . '</textarea>';
+                    break;
+                case 'select':
+                    echo '<select name="' . esc_attr($key) . '">';
+                    foreach ($field['options'] as $opt) {
+                        $selected = selected($val, $opt, false);
+                        echo '<option value="' . esc_attr($opt) . '" ' . $selected . '>' . esc_html($opt) . '</option>';
+                    }
+                    echo '</select>';
+                    break;
+                default:
+                    echo '<input type="' . esc_attr($type) . '" name="' . esc_attr($key) . '" value="' . $val . '" />';
+            }
+            echo '</label></p>';
+        }
+    }
+}

--- a/wp-studio-manager/wp-studio-manager.php
+++ b/wp-studio-manager/wp-studio-manager.php
@@ -13,21 +13,22 @@ define("WSM_PLUGIN_DIR", plugin_dir_path(__FILE__));
 define("WSM_PLUGIN_URL", plugin_dir_url(__FILE__));
 
 // Autoloader and core classes
-require_once WSM_PLUGIN_DIR . 'core/class-gm-loader.php';
-require_once WSM_PLUGIN_DIR . 'core/class-gm-activator.php';
-require_once WSM_PLUGIN_DIR . 'core/class-gm-deactivator.php';
-require_once WSM_PLUGIN_DIR . 'core/class-gm-plugin.php';
+require_once WSM_PLUGIN_DIR . 'core/class-wsm-loader.php';
+require_once WSM_PLUGIN_DIR . 'core/class-wsm-activator.php';
+require_once WSM_PLUGIN_DIR . 'core/class-wsm-deactivator.php';
+require_once WSM_PLUGIN_DIR . 'core/class-wsm-plugin.php';
+require_once WSM_PLUGIN_DIR . 'admin/controllers/class-participants-controller.php';
 
-use WSM\Core\GM_Loader;
-use WSM\Core\GM_Activator;
-use WSM\Core\GM_Deactivator;
-use WSM\Core\GM_Plugin;
+use WSM\Core\WSM_Loader;
+use WSM\Core\WSM_Activator;
+use WSM\Core\WSM_Deactivator;
+use WSM\Core\WSM_Plugin;
 use WSM\Includes\Industry_Configs\Industry_Config;
 
-GM_Loader::register();
+WSM_Loader::register();
 
-register_activation_hook(__FILE__, array('WSM\\Core\\GM_Activator', 'activate'));
-register_deactivation_hook(__FILE__, array('WSM\\Core\\GM_Deactivator', 'deactivate'));
+register_activation_hook(__FILE__, array('WSM\\Core\\WSM_Activator', 'activate'));
+register_deactivation_hook(__FILE__, array('WSM\\Core\\WSM_Deactivator', 'deactivate'));
 
 // Function to create the custom role for coaches
 function gm_add_coach_role() {
@@ -168,5 +169,5 @@ function gm_register_custom_post_types() {
 add_action('init', 'gm_register_custom_post_types');
 
 // Run plugin
-GM_Plugin::instance()->run();
+WSM_Plugin::instance()->run();
 ?>


### PR DESCRIPTION
## Summary
- add flexible custom field definitions to industry config classes
- implement `Industry_Helper` utilities for dynamic form generation
- create `Participants_Controller` and display industry-specific fields
- update menu and JS to handle dynamic terminology and navigation
- initialize new WSM core classes

## Testing
- `php` was not available, so syntax checks were skipped

------
https://chatgpt.com/codex/tasks/task_e_68464a2515808321812859887b110a98